### PR TITLE
Resolving NuGet packages references without reading nuget.config

### DIFF
--- a/specs/CodeAnalysis.TestTools.Specs/NuGet_packages_specs.cs
+++ b/specs/CodeAnalysis.TestTools.Specs/NuGet_packages_specs.cs
@@ -2,10 +2,7 @@
 
 namespace NuGet_packages_specs;
 
-#if RELEASE
-    [TestFixture(Ignore = "Not on build")]
-#endif
-    public class Latest_versions
+public class Latest_versions
 {
     [Test]
     public void Newtonsoft_Json()

--- a/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
+++ b/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
@@ -11,6 +11,8 @@
     <Description>Tooling to describe expected static code analyzer behavior in annotated code files.</Description>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <PackageReleaseNotes>
+ToBeReleased
+- Don't try to read the NuGet V3 url from a config file.
 v1.1.0
 - Support additional files for projects.
 v1.0.0

--- a/src/CodeAnalysis.TestTools/References/NuGetRepository.cs
+++ b/src/CodeAnalysis.TestTools/References/NuGetRepository.cs
@@ -9,6 +9,8 @@ namespace CodeAnalysis.TestTools.References;
 
 internal static class NuGetRepository
 {
+    private static readonly Uri NuGetV3 = new("https://api.nuget.org/v3/index.json");
+
     public static async Task DownloadAsync(NuGetPackage package)
     {
         var resource = await Repo();
@@ -62,14 +64,7 @@ internal static class NuGetRepository
 
     [Pure]
     private static Task<FindPackageByIdResource> Repo()
-        => Repository.Factory.GetCoreV3(NuGetOrgUrl()).GetResourceAsync<FindPackageByIdResource>();
-
-    [Pure]
-    private static string NuGetOrgUrl()
-        => Settings
-        .LoadSpecificSettings(new DirectoryInfo(@"..\..\..").FullName, "nuget.config")
-        .GetSection("packageSources").Items.OfType<AddItem>()
-        .Single(x => x.Key == "nuget.org").Value;
+        => Repository.Factory.GetCoreV3(NuGetV3.AbsoluteUri).GetResourceAsync<FindPackageByIdResource>();
 
     [Pure]
     private static async Task<NuGetLatestVersions> GetLatestVersionsCacheAsync()


### PR DESCRIPTION
Dropped the logic to resolve the URL of the NuGet V3 endpoint by reading a config file.