### PR TITLE
Ensure the projects are build by test tools

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,6 +14,6 @@ jobs:
       with:
         dotnet-version: '7.0.x'
     - name: Build with dotnet
-      run: dotnet build --configuration Release
+      run: dotnet build build.sln --configuration Release
     - name: Run unit tests
-      run: dotnet test --no-build --configuration Release
+      run: dotnet test build.sln --no-build --configuration Release

--- a/Roslyn.TestTools.sln
+++ b/Roslyn.TestTools.sln
@@ -25,9 +25,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{00B4E265-2A4D-4204-B879-E593ED212EED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpProject", "projects\CSharpProject\CSharpProject.csproj", "{42EF7669-4A0D-432E-8789-C61A72EBC517}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpProject", "projects\CSharpProject\CSharpProject.csproj", "{42EF7669-4A0D-432E-8789-C61A72EBC517}"
 EndProject
-Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "VbProject", "projects\VbProject\VbProject.vbproj", "{9D73C6DF-C324-4A45-A37C-396F786B401D}"
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "VbProject", "projects\VbProject\VbProject.vbproj", "{9D73C6DF-C324-4A45-A37C-396F786B401D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{6D1DD7FB-7224-4693-B0F1-0FA95D7747CE}"
+	ProjectSection(SolutionItems) = preProject
+		projects\props\common.props = projects\props\common.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +65,7 @@ Global
 		{7C583E7B-BCA6-47E9-B89E-A546C94010A1} = {5811F55D-6885-4288-8C7D-862CC2B43D7F}
 		{42EF7669-4A0D-432E-8789-C61A72EBC517} = {00B4E265-2A4D-4204-B879-E593ED212EED}
 		{9D73C6DF-C324-4A45-A37C-396F786B401D} = {00B4E265-2A4D-4204-B879-E593ED212EED}
+		{6D1DD7FB-7224-4693-B0F1-0FA95D7747CE} = {00B4E265-2A4D-4204-B879-E593ED212EED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {59DFE69B-0C3B-4ADA-AB6A-4C72A52D5C08}

--- a/build.sln
+++ b/build.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeAnalysis.TestTools", "src\CodeAnalysis.TestTools\CodeAnalysis.TestTools.csproj", "{327D0311-16C3-41FD-A8F7-3E75BE2D63E4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeAnalysis.TestTools.Specs", "specs\CodeAnalysis.TestTools.Specs\CodeAnalysis.TestTools.Specs.csproj", "{E1ED020E-C14E-4375-8190-A89131D37C2E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{327D0311-16C3-41FD-A8F7-3E75BE2D63E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{327D0311-16C3-41FD-A8F7-3E75BE2D63E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{327D0311-16C3-41FD-A8F7-3E75BE2D63E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{327D0311-16C3-41FD-A8F7-3E75BE2D63E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1ED020E-C14E-4375-8190-A89131D37C2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1ED020E-C14E-4375-8190-A89131D37C2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1ED020E-C14E-4375-8190-A89131D37C2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1ED020E-C14E-4375-8190-A89131D37C2E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {59DFE69B-0C3B-4ADA-AB6A-4C72A52D5C08}
+	EndGlobalSection
+EndGlobal

--- a/projects/CSharpProject/CSharpProject.csproj
+++ b/projects/CSharpProject/CSharpProject.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../props/common.props"/>
+  
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -11,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Qowaiv" Version="6.4.1" />
+    <PackageReference Update="Qowaiv" Version="6.4.1" />
   </ItemGroup>
 
 </Project>

--- a/projects/VbProject/VbProject.vbproj
+++ b/projects/VbProject/VbProject.vbproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <RootNamespace>VbProject</RootNamespace>
-    <TargetFramework>nestandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/VbProject/VbProject.vbproj
+++ b/projects/VbProject/VbProject.vbproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <RootNamespace>VbProject</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>nestandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/VbProject/VbProject.vbproj
+++ b/projects/VbProject/VbProject.vbproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../props/common.props"/>
+  
   <PropertyGroup>
     <RootNamespace>VbProject</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/VbProject/VbProject.vbproj
+++ b/projects/VbProject/VbProject.vbproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../props/common.props"/>
+  <Import Project="../props/common.props" />
   
   <PropertyGroup>
     <RootNamespace>VbProject</RootNamespace>

--- a/projects/VbProject/VbProject.vbproj
+++ b/projects/VbProject/VbProject.vbproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Qowaiv" Version="6.4.1" />
+    <PackageReference Update="Qowaiv" Version="6.4.1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/projects/props/common.props
+++ b/projects/props/common.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Builder.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Builder.cs
@@ -24,9 +24,6 @@ public abstract partial record AnalyzerVerifyContext<TContext> : AnalyzerVerifyC
     /// <summary>Gets the sources (snippets, files) to verify with.</summary>
     public Sources Sources { get; init; }
 
-    /// <summary>Gets the (external) references to compile with.</summary>
-    public MetadataReferences References { get; init; } = MetadataReferences.Empty;
-
     /// <summary>Adds an (optional) extra analyzer.</summary>
     [Pure]
     public TContext Add(DiagnosticAnalyzer analyzer)

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Builder.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Builder.cs
@@ -12,7 +12,6 @@ public abstract partial record AnalyzerVerifyContext<TContext> : AnalyzerVerifyC
     protected AnalyzerVerifyContext()
     {
         Sources = new Sources(Language);
-        References = Reference.Defaults;
     }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Extensions.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Extensions.cs
@@ -1,0 +1,23 @@
+﻿namespace CodeAnalysis.TestTools.Contexts;
+
+/// <summary>Extensions on <see cref="AnalyzerVerifyContext"/>.</summary>
+public static class AnalyzerVerifyContextExtensions
+{
+    /// <summary>Adds an (optional) extra analyzer.</summary>
+    [Pure]
+    public static TContext Add<TContext>(this TContext context, DiagnosticAnalyzer analyzer)
+        where TContext : AnalyzerVerifyContext
+        => context with
+        {
+            Analyzers = context.Analyzers.Add(analyzer),
+        };
+
+    /// <summary>Adds (optional) extra analyzers.</summary>
+    [Pure]
+    public static TContext Add<TContext>(this TContext context, params DiagnosticAnalyzer[] analyzers)
+        where TContext : AnalyzerVerifyContext
+        => context with
+        {
+            Analyzers = context.Analyzers.AddRange(analyzers),
+        };
+}

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -25,9 +25,10 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
     {
         var project = Project.AddMetadataReferences(References);
 
-        if(Language == Language.VisualBasic)
+        Console.Write(project.Language);
+        if (Language == Language.VisualBasic)
         {
-            foreach(var reference in project.MetadataReferences)
+            foreach (var reference in project.MetadataReferences)
             {
                 Console.WriteLine($"- {reference.Display} ({reference.GetType().Name})");
             }

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -24,10 +24,7 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
     {
         foreach (var reference in Project.MetadataReferences)
         {
-            if (reference is UnresolvedMetadataReference)
-            {
-                throw new InvalidOperationException($"Could not resolve {reference.Display}.");
-            }
+            Console.WriteLine($"{reference.Display} ({reference.GetType()})");
         }
         return Project.GetCompilationAsync()!;
     }

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -23,7 +23,16 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
     [Pure]
     public override Task<Compilation> GetCompilationAsync()
     {
-        return Project.AddMetadataReferences(References).GetCompilationAsync()!;
+        var project = Project.AddMetadataReferences(References);
+
+        if(Language == Language.VisualBasic)
+        {
+            foreach(var reference in project.MetadataReferences)
+            {
+                Console.WriteLine($"- {reference.Display} ({reference.GetType().Name})");
+            }
+        }
+        return project.GetCompilationAsync()!;
     }
 
     /// <summary>Adds an (optional) extra analyzer.</summary>

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -6,10 +6,11 @@
 public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
 {
     /// <summary>Initializes a new instance of the <see cref="VisualBasicAnalyzerVerifyContext"/> class.</summary>
-    public ProjectAnalyzerVerifyContext(Project project)
+    public ProjectAnalyzerVerifyContext(Project project, MetadataReferences? references)
     {
         Project = Guard.NotNull(project);
         Analyzers = new Analyzers(Language);
+        References = References.AddRange(references ?? MetadataReferences.Empty);
     }
 
     /// <summary>Gets the project.</summary>
@@ -20,14 +21,8 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
 
     /// <summary>Gets the compilation.</summary>
     [Pure]
-    public override Task<Compilation> GetCompilationAsync()
-    {
-        foreach (var reference in Project.MetadataReferences)
-        {
-            Console.WriteLine($"{reference.Display} ({reference.GetType()})");
-        }
-        return Project.GetCompilationAsync()!;
-    }
+    public override Task<Compilation> GetCompilationAsync() 
+        => Project.AddMetadataReferences(References).GetCompilationAsync()!;
 
     /// <summary>Adds an (optional) extra analyzer.</summary>
     [Pure]

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -23,7 +23,9 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
     [Pure]
     public override Task<Compilation> GetCompilationAsync()
     {
-        var project = Project;//.AddMetadataReferences(References);
+        var project = Project
+            .AddMetadataReference(Reference.Netstandard) 
+            .AddMetadataReferences(References);
 
         Console.Write($"Language = {project.Language}");
         if (Language == Language.VisualBasic)

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -27,6 +27,7 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
 
         if(Language == Language.VisualBasic)
         {
+            project = project.AddMetadataReferences(NuGetPackage.Microsoft_VisualBasic());
             foreach(var reference in project.MetadataReferences)
             {
                 Console.WriteLine($"- {reference.Display} ({reference.GetType().Name})");

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -10,7 +10,7 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
     {
         Project = Guard.NotNull(project);
         Analyzers = new Analyzers(Language);
-        References = References.AddRange(references ?? MetadataReferences.Empty);
+        References = references ?? MetadataReferences.Empty;
     }
 
     /// <summary>Gets the project.</summary>
@@ -21,8 +21,10 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
 
     /// <summary>Gets the compilation.</summary>
     [Pure]
-    public override Task<Compilation> GetCompilationAsync() 
-        => Project.AddMetadataReferences(References).GetCompilationAsync()!;
+    public override Task<Compilation> GetCompilationAsync()
+    {
+        return Project.AddMetadataReferences(References).GetCompilationAsync()!;
+    }
 
     /// <summary>Adds an (optional) extra analyzer.</summary>
     [Pure]

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -27,7 +27,6 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
 
         if(Language == Language.VisualBasic)
         {
-            project = project.AddMetadataReferences(NuGetPackage.Microsoft_VisualBasic());
             foreach(var reference in project.MetadataReferences)
             {
                 Console.WriteLine($"- {reference.Display} ({reference.GetType().Name})");

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -23,9 +23,9 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
     [Pure]
     public override Task<Compilation> GetCompilationAsync()
     {
-        var project = Project.AddMetadataReferences(References);
+        var project = Project;//.AddMetadataReferences(References);
 
-        Console.Write(project.Language);
+        Console.Write($"Language = {project.Language}");
         if (Language == Language.VisualBasic)
         {
             foreach (var reference in project.MetadataReferences)

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.Project.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-
-namespace CodeAnalysis.TestTools.Contexts;
+﻿namespace CodeAnalysis.TestTools.Contexts;
 
 /// <summary>
 /// Represents a project file based context to verify <see cref="DiagnosticAnalyzer"/> behavior.
@@ -23,7 +21,16 @@ public record ProjectAnalyzerVerifyContext : AnalyzerVerifyContext
     /// <summary>Gets the compilation.</summary>
     [Pure]
     public override Task<Compilation> GetCompilationAsync()
-        => Project.GetCompilationAsync()!;
+    {
+        foreach (var reference in Project.MetadataReferences)
+        {
+            if (reference is UnresolvedMetadataReference)
+            {
+                throw new InvalidOperationException($"Could not resolve {reference.Display}.");
+            }
+        }
+        return Project.GetCompilationAsync()!;
+    }
 
     /// <summary>Adds an (optional) extra analyzer.</summary>
     [Pure]

--- a/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.cs
+++ b/src/CodeAnalysis.TestTools/Contexts/AnalyzerVerifyContext.cs
@@ -9,6 +9,7 @@ public abstract record AnalyzerVerifyContext
     protected AnalyzerVerifyContext()
     {
         Analyzers = new Analyzers(Language);
+        References = Reference.Defaults;
     }
 
     /// <summary>Gets the language (of the options sources etc.).</summary>
@@ -16,6 +17,9 @@ public abstract record AnalyzerVerifyContext
 
     /// <summary>Gets the analyzer(s) to verify for.</summary>
     public Analyzers Analyzers { get; init; }
+
+    /// <summary>Gets the (external) references to compile with.</summary>
+    public MetadataReferences References { get; init; } = MetadataReferences.Empty;
 
     /// <summary>Gets the diagnostic ID's toe ignore.</summary>
     public DiagnosticIds IgnoredDiagnostics { get; init; } = DiagnosticIds.Empty;

--- a/src/CodeAnalysis.TestTools/MsBuild/Import.cs
+++ b/src/CodeAnalysis.TestTools/MsBuild/Import.cs
@@ -14,4 +14,9 @@ internal sealed class Import
     }
 
     public MsBuildProject? Project { get; }
+
+    public override string ToString()
+        => Project is { }
+        ? $@"<Import Project=""{Project.Path.FullName}"" />"
+        : "<Import />";
 }

--- a/src/CodeAnalysis.TestTools/MsBuild/Import.cs
+++ b/src/CodeAnalysis.TestTools/MsBuild/Import.cs
@@ -1,0 +1,17 @@
+﻿using System.Xml.Linq;
+
+namespace CodeAnalysis.TestTools.MsBuild;
+
+internal sealed class Import
+{
+    internal Import(XElement element, FileInfo project)
+    {
+        if (element.Attribute(nameof(Project))?.Value is { } path
+            && new FileInfo(Path.Combine(project.Directory!.FullName, path)) is { Exists: true } location)
+        {
+            Project = MsBuildProject.Load(location);
+        }
+    }
+
+    public MsBuildProject? Project { get; }
+}

--- a/src/CodeAnalysis.TestTools/MsBuild/MsBuildProject.cs
+++ b/src/CodeAnalysis.TestTools/MsBuild/MsBuildProject.cs
@@ -1,0 +1,68 @@
+﻿using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace CodeAnalysis.TestTools.MsBuild;
+
+internal sealed class MsBuildProject
+{
+    internal MsBuildProject(XElement element, FileInfo path)
+    {
+        Imports = element
+            .XPathSelectElements($"//{nameof(Import)}")
+            .Select(e => new Import(e, path))
+            .ToArray();
+
+        PackageReferences = element
+            .XPathSelectElements($"//{nameof(PackageReference)}")
+            .Select(e => new PackageReference(e))
+            .ToArray();
+
+        Path = path;
+    }
+
+    public FileInfo Path { get; }
+
+    public IReadOnlyCollection<Import> Imports { get; }
+    public IReadOnlyCollection<PackageReference> PackageReferences { get; private set; }
+
+    public MetadataReferences MetadataReferences()
+    {
+        var lookup = new Dictionary<string, string?>();
+
+        foreach (var p in ImportsAndSelf())
+        {
+            if ((p.Include ?? p.Update) is { Length: > 0 } key)
+            {
+                lookup[key] = p.Version;
+            }
+        }
+
+        var references = new MetadataReferences();
+
+        foreach (var kvp in lookup)
+        {
+            references = references.AddRange(NuGetPackage.Resolve(kvp.Key, kvp.Value));
+        }
+        return references;
+    }
+
+    private IEnumerable<PackageReference> ImportsAndSelf()
+    {
+        foreach (var import in Imports
+            .Select(i => i.Project).OfType<MsBuildProject>()
+            .SelectMany(i => i.ImportsAndSelf()))
+        {
+            yield return import;
+        }
+        foreach (var p in PackageReferences)
+        {
+            yield return p;
+        }
+    }
+
+    public static MsBuildProject Load(FileInfo path)
+    {
+        var document = XDocument.Load(path.FullName);
+        return new(document.Root!, path);
+    }
+}

--- a/src/CodeAnalysis.TestTools/MsBuild/PackageReference.cs
+++ b/src/CodeAnalysis.TestTools/MsBuild/PackageReference.cs
@@ -1,0 +1,17 @@
+﻿using System.Xml.Linq;
+
+namespace CodeAnalysis.TestTools.MsBuild;
+
+internal sealed class PackageReference
+{
+    internal PackageReference(XElement element)
+    {
+        Include = element.Attribute(nameof(Include))?.Value;
+        Update = element.Attribute(nameof(Update))?.Value;
+        Version = element.Attribute(nameof(Version))?.Value;
+    }
+
+    public string? Include { get; }
+    public string? Update { get; }
+    public string? Version { get; }
+}

--- a/src/CodeAnalysis.TestTools/MsBuild/PackageReference.cs
+++ b/src/CodeAnalysis.TestTools/MsBuild/PackageReference.cs
@@ -14,4 +14,23 @@ internal sealed class PackageReference
     public string? Include { get; }
     public string? Update { get; }
     public string? Version { get; }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder("<PackageReference ");
+        if(Include is { })
+        {
+            sb.Append($@"Include=""{Include}"" ");
+        }
+        if (Update is { })
+        {
+            sb.Append($@"Update=""{Update}"" ");
+        }
+        if (Version is { })
+        {
+            sb.Append($@"Version=""{Version}"" ");
+        }
+        sb.Append("/>");
+        return sb.ToString();
+    }
 }

--- a/src/CodeAnalysis.TestTools/VerifyAnalyzer.cs
+++ b/src/CodeAnalysis.TestTools/VerifyAnalyzer.cs
@@ -27,7 +27,8 @@ public static class VerifyAnalyzer
     public static ProjectAnalyzerVerifyContext ForProject(this DiagnosticAnalyzer analyzer, FileInfo location)
     {
         Guard.Exists(location);
-        var context = new ProjectAnalyzerVerifyContext(ProjectLoader.Load(location));
+        var project = MsBuild.MsBuildProject.Load(location);
+        var context = new ProjectAnalyzerVerifyContext(ProjectLoader.Load(location), project.MetadataReferences());
         return context.Add(analyzer);
     }
 


### PR DESCRIPTION
If the project is compiled by MS Build, this might hide that the TestTools themselves don't build the project correctly.