### PR TITLE
Update to BuildAnalyzers 6 and drop .NET 7 support

### DIFF
--- a/projects/CSharpProject/CSharpProject.csproj
+++ b/projects/CSharpProject/CSharpProject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/specs/CodeAnalysis.TestTools.Specs/Language_specs.cs
+++ b/specs/CodeAnalysis.TestTools.Specs/Language_specs.cs
@@ -1,0 +1,24 @@
+﻿namespace Language_specs;
+
+public class Parses
+{
+    [TestCase(".xml")]
+    [TestCase("EXTENSIBLEMARKUPLANGUAGE")]
+    [TestCase("XML")]
+    public void as_XML(string str)
+        => Language.Parse(str).Should().Be(Language.XML);
+
+    [TestCase(".fs")]
+    [TestCase("FSharp")]
+    [TestCase("F#")]
+    [TestCase("fs")]
+    public void as_FSharp(string str)
+       => Language.Parse(str).Should().Be(Language.FSharp);
+}
+
+public class Does_not_parse
+{
+    [Test]
+    public void garbage()
+        => "garbage".Invoking(Language.Parse).Should().Throw<FormatException>();
+}

--- a/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
+++ b/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
@@ -1,16 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
-    <Version>1.3.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Corniel Nobel</Authors>
     <Product>Roslyn static code analyzers test tools</Product>
     <Description>Tooling to describe expected static code analyzer behavior in annotated code files.</Description>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <PackageReleaseNotes>
+v2.0.0
+- Drop .NET 7.0 support. (breaking)
+- Update dependency Buildalyzer 6.*. (breaking)
 v1.3.0
 - Target .NET 8.0
 v1.2.0
@@ -29,8 +32,8 @@ v0.0.3.1
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buildalyzer" Version="5.0.1" />
-    <PackageReference Include="Buildalyzer.Workspaces" Version="5.0.1" />
+    <PackageReference Include="Buildalyzer" Version="6.0.4" />
+    <PackageReference Include="Buildalyzer.Workspaces" Version="6.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.8.0" />

--- a/src/CodeAnalysis.TestTools/Diagnostics/Contracts/InheritableAttribute.cs
+++ b/src/CodeAnalysis.TestTools/Diagnostics/Contracts/InheritableAttribute.cs
@@ -3,7 +3,8 @@
 /// <summary>Indicates the a class is designed to be inheritable.</summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 [Conditional("CONTRACTS_FULL")]
-internal class InheritableAttribute : Attribute
+[ExcludeFromCodeCoverage(Justification = "Decoration only.")]
+internal sealed class InheritableAttribute : Attribute
 {
     /// <summary>Initializes a new instance of the <see cref="InheritableAttribute"/> class.</summary>
     public InheritableAttribute(string? message = null) => _ = message;

--- a/src/CodeAnalysis.TestTools/Diagnostics/ExpectedIssueParser.Pattern.cs
+++ b/src/CodeAnalysis.TestTools/Diagnostics/ExpectedIssueParser.Pattern.cs
@@ -15,7 +15,7 @@ internal static class Pattern
 
     public static readonly Regex Regular = Rx(comment, position_regular, issue_type, offset, start_length, diagnostic_id, message);
     public static readonly Regex Precise = Rx(@"^\s*", comment, position_precise, issue_type, "?", offset, diagnostic_id, message, @"\s*(-->|\*/)?$");
-    public static readonly Regex Iregular = Rx(comment, ".*", issue_type);
+    public static readonly Regex Irregular = Rx(comment, ".*", issue_type);
     public static readonly Regex Unprecise = Rx(@"^\s*", comment, ".*", position_precise);
 
     [Pure]

--- a/src/CodeAnalysis.TestTools/Diagnostics/ExpectedIssueParser.cs
+++ b/src/CodeAnalysis.TestTools/Diagnostics/ExpectedIssueParser.cs
@@ -26,7 +26,7 @@ internal static partial class ExpectedIssueParser
             {
                 regulars.Add(IssueFromMatch(regular.NoRemainingCurlyBrace(line), line.LineNumber));
             }
-            else if (Pattern.Unprecise.IsMatch(line.Text) || Pattern.Iregular.IsMatch(line.Text))
+            else if (Pattern.Unprecise.IsMatch(line.Text) || Pattern.Irregular.IsMatch(line.Text))
             {
                 throw ParseError.New(Messages.ParseError_InvalidPattern, line.LineNumber);
             }

--- a/src/CodeAnalysis.TestTools/Language.cs
+++ b/src/CodeAnalysis.TestTools/Language.cs
@@ -79,7 +79,7 @@ public readonly struct Language : IEquatable<Language>
             "CSHARP" or "CS" or "C#" or ".CS" => CSharp,
             "VB" or "VBNET" or "VISUALBASIC" or ".VB" => VisualBasic,
             "FSHARP" or "FS" or "F#" or ".FS" => FSharp,
-            "XML" or "EXTENSIBLEMARKUPLANGUAGE" or ".XML" => FSharp,
+            "XML" or "EXTENSIBLEMARKUPLANGUAGE" or ".XML" => XML,
             _ => throw new FormatException(Messages.Language_InvalidFormat),
         };
 


### PR DESCRIPTION
Depending on BuildAnalyzer 6 (breaking). While at it, also dropped .NET 7 support.