### PR TITLE
Logging expected issues to the console only in DEBUG mode

### DIFF
--- a/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
+++ b/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
@@ -11,6 +11,8 @@
     <Description>Tooling to describe expected static code analyzer behavior in annotated code files.</Description>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <PackageReleaseNotes>
+To Be released
+- Logging expected issues to the console only in DEBUG mode.
 v2.0.0
 - Drop .NET 7.0 support. (breaking)
 - Update dependency Buildalyzer 6.*. (breaking)

--- a/src/CodeAnalysis.TestTools/Diagnostics/IssueVerifier.cs
+++ b/src/CodeAnalysis.TestTools/Diagnostics/IssueVerifier.cs
@@ -27,24 +27,32 @@ public static class IssueVerifier
     public static IEnumerable<Issue> Log(this IEnumerable<Issue> issues, TextWriter? writer = null)
     {
         Guard.NotNull(issues);
-        writer ??= Console.Out;
 
-        writer.WriteLine(issues.GetReportInfoHeader());
+        AttachConsole(ref writer);
 
-        var filePath = string.Empty;
-
-        foreach (var issue in issues)
+        if (writer is { })
         {
-            if (issue.Location.FilePath != filePath)
-            {
-                filePath = issue.Location.FilePath;
-                writer.WriteLine($"File: {filePath}");
-            }
-            writer.WriteLine(issue.ReportInfo());
-        }
+            writer.WriteLine(issues.GetReportInfoHeader());
 
+            var filePath = string.Empty;
+
+            foreach (var issue in issues)
+            {
+                if (issue.Location.FilePath != filePath)
+                {
+                    filePath = issue.Location.FilePath;
+                    writer.WriteLine($"File: {filePath}");
+                }
+                writer.WriteLine(issue.ReportInfo());
+            }
+        }
         return issues;
     }
+
+    /// <summary>Attaches the console in DEBUG mode.</summary>
+    [Conditional("DEBUG")]
+    private static void AttachConsole(ref TextWriter? writer)
+        => writer ??= Console.Out;
 
     /// <summary>Represents the report info of the issues.</summary>
     [Pure]


### PR DESCRIPTION
When running in release mode (typically on builds) having expected issues logged is considered noise.