### PR TITLE
'no message provided' on Verify()

### DIFF
--- a/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
+++ b/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
@@ -7,26 +7,28 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>3.0.0</Version>
     <PackageReleaseNotes>
-      v3.0.0
-      - Logging expected issues to the console only in DEBUG mode.
-      - Update dependency Buildalyzer 7.*. (breaking)
-      v2.0.0
-      - Drop .NET 7.0 support. (breaking)
-      - Update dependency Buildalyzer 6.*. (breaking)
-      v1.3.0
-      - Target .NET 8.0
-      v1.2.0
-      - Build with Buildalyzer.
-      - Don't try to read the NuGet V3 url from a config file.
-      v1.1.0
-      - Support additional files for projects.
-      v1.0.0
-      - Support verifying against projects.
-      v0.0.4
-      - Support for verifying code fix providers. (#7)
-      - Fix invalid cast for adding NuGet packages.
-      v0.0.3.1
-      - GuardedCollection AddRange failed to add items to the new collection. (#4)
+v3.0.1
+- 'no message provided' on Verify method (FIX). #10
+v3.0.0
+- Logging expected issues to the console only in DEBUG mode.
+- Update dependency Buildalyzer 7.*. (breaking)
+v2.0.0
+- Drop .NET 7.0 support. (breaking)
+- Update dependency Buildalyzer 6.*. (breaking)
+v1.3.0
+- Target .NET 8.0
+v1.2.0
+- Build with Buildalyzer.
+- Don't try to read the NuGet V3 url from a config file.
+v1.1.0
+- Support additional files for projects.
+v1.0.0
+- Support verifying against projects.
+v0.0.4
+- Support for verifying code fix providers. (#7)
+- Fix invalid cast for adding NuGet packages.
+v0.0.3.1
+- GuardedCollection AddRange failed to add items to the new collection. (#4)
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
+++ b/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
@@ -5,10 +5,10 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <PackageReleaseNotes>
 v3.0.1
-- 'no message provided' on Verify method (FIX). #10
+- 'no message provided' on Verify method (FIX). #21
 v3.0.0
 - Logging expected issues to the console only in DEBUG mode.
 - Update dependency Buildalyzer 7.*. (breaking)

--- a/src/CodeAnalysis.TestTools/Diagnostics/IssueVerifier.cs
+++ b/src/CodeAnalysis.TestTools/Diagnostics/IssueVerifier.cs
@@ -45,6 +45,8 @@ public static class IssueVerifier
                 }
                 writer.WriteLine(issue.ReportInfo());
             }
+
+            writer.Flush();
         }
         return issues;
     }


### PR DESCRIPTION
Due to a missing `writer.Flush()`.