### PR TITLE
Verify takes the severity of the reported issue into account

### DIFF
--- a/specs/CodeAnalysis.TestTools.Specs/Analyzers/ReportError.cs
+++ b/specs/CodeAnalysis.TestTools.Specs/Analyzers/ReportError.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Specs.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class ReportError : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => [new DiagnosticDescriptor(nameof(ReportError), "Reports Error", "Do not use classes", string.Empty, DiagnosticSeverity.Error, true)];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+        context.RegisterSyntaxNodeAction(
+            c => c.ReportDiagnostic(Diagnostic.Create(SupportedDiagnostics[0], c.Node.GetLocation())),
+            SyntaxKind.ClassDeclaration);
+    }
+}

--- a/specs/CodeAnalysis.TestTools.Specs/Verify.cs
+++ b/specs/CodeAnalysis.TestTools.Specs/Verify.cs
@@ -1,0 +1,6 @@
+namespace Specs;
+
+internal static class Verify
+{
+    public static Action That(Action action) => action;
+}

--- a/specs/CodeAnalysis.TestTools.Specs/Verify_fix_specs.cs
+++ b/specs/CodeAnalysis.TestTools.Specs/Verify_fix_specs.cs
@@ -1,3 +1,4 @@
+using Specs;
 using Specs.CodeFixers;
 
 namespace Verify_fix_specs;
@@ -6,55 +7,43 @@ public class Requires
 {
     [Test]
     public void any_source()
-    {
-        Action verify = () => new CSharpOnly().ForCS()
+        => Verify.That(() => new CSharpOnly().ForCS()
             .ForCodeFix<EmptyFix>()
             .AddSnippet("class SomeClass { }")
-            .Verify();
-
-        verify.Should().Throw<IncompleteSetup>()
+            .Verify())
+            .Should().Throw<IncompleteSetup>()
             .WithMessage("The setup is incomplete. No sources have been configured.");
-    }
 
     [Test]
     public void any_expected_source()
-    {
-        Action verify = () => new CSharpOnly().ForCS()
+        => Verify.That(() => new CSharpOnly().ForCS()
             .AddSnippet("class SomeClass { }")
             .ForCodeFix<EmptyFix>()
-            .Verify();
-
-        verify.Should().Throw<IncompleteSetup>()
+            .Verify())
+            .Should().Throw<IncompleteSetup>()
             .WithMessage("The setup is incomplete. No expected sources have been configured.");
-    }
 
     [Test]
     public void singe_source()
-    {
-        Action verify = () => new CSharpOnly().ForCS()
+        => Verify.That(() => new CSharpOnly().ForCS()
             .AddSnippet("class SomeClass { }")
             .AddSnippet("class SecondClass { }")
             .ForCodeFix<EmptyFix>()
             .AddSnippet("class OutputClass { }")
-            .Verify();
-
-        verify.Should().Throw<NotSupportedException>()
+            .Verify())
+            .Should().Throw<NotSupportedException>()
             .WithMessage("A code fix can only be applied on a single source.");
-    }
 
     [Test]
     public void single_expected_source()
-    {
-        Action verify = () => new CSharpOnly().ForCS()
+        => Verify.That(() => new CSharpOnly().ForCS()
             .AddSnippet("class InputClass { }")
             .ForCodeFix<EmptyFix>()
             .AddSnippet("class SomeClass { }")
             .AddSnippet("class SecondClass { }")
-            .Verify();
-
-        verify.Should().Throw<NotSupportedException>()
+            .Verify())
+            .Should().Throw<NotSupportedException>()
             .WithMessage("A code fix can only be verified against a single source.");
-    }
 }
 
 public class Succeeds_when
@@ -88,9 +77,9 @@ class SomeClass
 
     [Test]
     public void multiple_issues_are_fixed()
-     => new PreferConstants()
-        .ForCS()
-        .AddSnippet(@"
+        => new PreferConstants()
+            .ForCS()
+            .AddSnippet(@"
 class SomeClass
 {
     int Answer()
@@ -128,15 +117,13 @@ public class Fails_when
 {
     [Test]
     public void single_issue_is_fixed()
-    {
-        Action verify = () => new PreferConstants()
-        .ForCS()
-        .AddSnippet(@"class SomeClass { }")
-        .ForCodeFix<PreferConstantsFix>()
-        .AddSnippet(@"class OtherClass { }")
-        .Verify();
-
-        verify.Should().Throw<VerificationFailed>()
+        => Verify.That(() => new PreferConstants()
+            .ForCS()
+            .AddSnippet(@"class SomeClass { }")
+            .ForCodeFix<PreferConstantsFix>()
+            .AddSnippet(@"class OtherClass { }")
+            .Verify())
+            .Should().Throw<VerificationFailed>()
             .WithMessage(@"The code fix had a different outcome than expected.
 Actual code after fix:
 class SomeClass { }
@@ -144,5 +131,4 @@ class SomeClass { }
 Expected code:
 class OtherClass { }
 ");
-    }
 }

--- a/specs/CodeAnalysis.TestTools.Specs/Verify_specs.cs
+++ b/specs/CodeAnalysis.TestTools.Specs/Verify_specs.cs
@@ -1,63 +1,50 @@
+using Specs;
+
 namespace Verify_specs;
 
 public class Crashes_when
 {
     [Test]
     public void analyzer_crashes()
-    {
-        Action verify = () => new CrashingAnalyzer()
+        => Verify.That(() => new CrashingAnalyzer()
             .ForCS()
             .AddSnippet("public class Dummy { }")
-            .Verify();
-
-        verify.Should()
+            .Verify())
+            .Should()
             .Throw<AnalyzerCrashed>()
             .WithMessage("Analyzer 'Specs.Analyzers.CrashingAnalyzer' threw an exception of type *");
-    }
 
     [Test]
     public void no_sources_provided()
-    {
-        Action verify = () => new CSharpOnly()
+        => Verify.That(() => new CSharpOnly()
             .ForCS()
-            .Verify();
-
-        verify.Should().Throw<IncompleteSetup>()
+            .Verify())
+            .Should().Throw<IncompleteSetup>()
             .WithMessage("The setup is incomplete. No sources have been configured.");
-    }
 }
 
 public class Succeeds_when
 {
     [Test]
     public void Non_precise_issue_is_found_on_same_line()
-    {
-        Action verify = () => new CSharpOnly()
+        => new CSharpOnly()
             .ForCS()
             .AddSnippet("public class MyClass { // Error")
             .Verify();
 
-        verify.Should().NotThrow();
-    }
-
     [Test]
     public void expected_location_is_matches_actual()
-    {
-        Action verify = () => new CSharpOnly()
+        => new CSharpOnly()
             .ForCS()
             .AddSnippet(@"public class MyClass { // Error ^37#0")
             .Verify();
-
-        verify.Should().NotThrow();
-    }
 }
 
 public class Supports
 {
     [Test]
     public void Unsafe_CSharp_when_enabled()
-    {
-        Action verify = () => new CSharpOnly()
+        => new CSharpOnly()
             .ForCS()
             .WithUnsafeCode(enable: true)
             .AddSnippet(@"
@@ -67,33 +54,34 @@ public class Supports
         }")
             .Verify();
 
-        verify.Should().NotThrow();
-    }
+    [Test]
+    public void Severity_of_analyzer_other_than_warning()
+        => new ReportError()
+            .ForCS()
+            .AddSnippet(@"
+        public class MyClass // Error {{Do not use classes}}
+        {
+        }")
+            .Verify();
 }
 
 public class Fails_when
 {
     [Test]
     public void Noncompliant_line_raises_error_instead()
-    {
-        Action verify = () => new CSharpOnly()
+        => Verify.That(() => new CSharpOnly()
             .ForCS()
             .AddSnippet("public class MyClass { // Noncompliant")
-            .Verify();
-
-        verify.Should().Throw<VerificationFailed>();
-    }
+            .Verify())
+            .Should().Throw<VerificationFailed>();
 
     [Test]
     public void expected_location_is_other_than_actual()
-    {
-        Action verify = () => new CSharpOnly()
+        => Verify.That(() => new CSharpOnly()
             .ForCS()
             .AddSnippet(@"
                     public class MyClass { // Error
                     //     ^^^^")
-            .Verify();
-
-        verify.Should().Throw<VerificationFailed>();
-    }
+            .Verify())
+        .Should().Throw<VerificationFailed>();
 }

--- a/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
+++ b/src/CodeAnalysis.TestTools/CodeAnalysis.TestTools.csproj
@@ -7,6 +7,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased
+- Verify takes the severity of the reported issue into account.
 - Add .NET 9.0.
 - Drop .NET 6.0. (BREAKING)
 - Removed [Serialize] attributes from exceptions.

--- a/src/CodeAnalysis.TestTools/Diagnostics/IssueLocation.cs
+++ b/src/CodeAnalysis.TestTools/Diagnostics/IssueLocation.cs
@@ -52,7 +52,7 @@ public sealed record IssueLocation : IComparable<IssueLocation>
     [Pure]
     public string ReportInfo()
         => IsPrecise()
-        ? $"@{LineNumber:00}[{Start,2}, {Start + SpanSize,2}]"
+        ? $"@{LineNumber:00}[{Start,2}, {Start!.Value + SpanSize!.Value,2}]"
         : $"@{LineNumber:00}[.., ..]";
 
     /// <summary>Return true if the location is defined precisely (with start and span size).</summary>

--- a/src/CodeAnalysis.TestTools/Extensions/DiagnosticExtensions.cs
+++ b/src/CodeAnalysis.TestTools/Extensions/DiagnosticExtensions.cs
@@ -5,16 +5,15 @@ public static class DiagnosticExtensions
 {
     /// <summary>Gets the issue type.</summary>
     [Pure]
-    public static IssueType GetIssueType(this Diagnostic diagnostic)
-        => Guard.NotNull(diagnostic).Severity switch
-        {
-            DiagnosticSeverity.Error => IssueType.Error,
-            _ => IssueType.Noncompliant,
-        };
+    public static IssueType GetIssueType(this Diagnostic diagnostic) => Guard.NotNull(diagnostic).Severity switch
+    {
+        DiagnosticSeverity.Error => IssueType.Error,
+        _ => IssueType.Noncompliant,
+    };
 
     /// <summary>Returns true it the diagnostic is warning from the compiler.</summary>
     [Pure]
-    public static bool IsAnalyzerCrashed(this Diagnostic diagnostic)
+    public static bool HasAnalyzerCrashed(this Diagnostic diagnostic)
         => Guard.NotNull(diagnostic).Id == DiagnosticId.AD0001;
 
     /// <summary>Returns true it the diagnostic is warning from the compiler.</summary>

--- a/src/CodeAnalysis.TestTools/Extensions/Microsoft.CodeAnalysis.Compilation.cs
+++ b/src/CodeAnalysis.TestTools/Extensions/Microsoft.CodeAnalysis.Compilation.cs
@@ -48,7 +48,7 @@ public static class CompilationExtensions
 
     [FluentSyntax]
     private static IReadOnlyCollection<Diagnostic> ThrowOnAnalyzerCrashed(this IReadOnlyCollection<Diagnostic> diagnostics)
-        => diagnostics.FirstOrDefault(d => d.IsAnalyzerCrashed()) is { } diagnostic
+        => diagnostics.FirstOrDefault(d => d.HasAnalyzerCrashed()) is { } diagnostic
             ? throw new AnalyzerCrashed(diagnostic.GetMessage())
             : diagnostics;
 


### PR DESCRIPTION
After this change, a analyzer that has a default severity other than a warning also reports as such.